### PR TITLE
forceZip option for files not named correctly

### DIFF
--- a/tarball.js
+++ b/tarball.js
@@ -3,8 +3,8 @@ var fs = require('fs')
  , zlib = require('zlib')
  , wget = require('wget')
  
-function extractTarball(sourceFile, destination, callback) {
-  if( /(gz|tgz)$/i.test(sourceFile)) {
+function extractTarball(sourceFile, destination, callback, forceZip) {
+  if( /(gz|tgz)$/i.test(sourceFile) || forceZip) {
     // This file is gzipped, use zlib to deflate the stream before passing to tar.
     fs.createReadStream(sourceFile)
     .pipe(zlib.createGunzip())


### PR DESCRIPTION
I have tar.gz files that have a different extension. This allows them to be forced as `.tar.gz`
