### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "main": "tarball.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/joshuah/sol-redis-pool.git"
+    "url": "git://github.com/joshuah/tarball-extract.git"
   },
-	"dependencies" : {
+  "dependencies" : {
     "tar" : "*",
-		"wget" : "*"
+    "wget" : "*"
   },
+  "license": "MIT",
   "engines": { "node": ">= 0.8.0" }
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/