### PR TITLE
Fix Tar Versioning in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git://github.com/joshuah/tarball-extract.git"
   },
   "dependencies" : {
-    "tar" : "*",
+    "tar" : "2.2.1",
     "wget" : "*"
   },
   "license": "MIT",


### PR DESCRIPTION
tar package API changed. Update the package.json to older version so API calls work. Fixes #8 