### PR TITLE
Change wget to node-wget-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "git://github.com/matsieftw/tarball-extract.git"
   },
   "dependencies": {
-    "tar": "2.2.1",
-    "wget": "*"
+    "node-wget-promise": "^0.1.3",
+    "tar": "2.2.1"
   },
   "license": "MIT",
   "engines": {

--- a/tarball.js
+++ b/tarball.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
  , tar = require('tar')
  , zlib = require('zlib')
- , wget = require('wget')
+ , wget = require('node-wget-promise')
  
 function extractTarball(sourceFile, destination, callback) {
   if( /(gz|tgz)$/i.test(sourceFile)) {
@@ -22,15 +22,14 @@ function extractTarball(sourceFile, destination, callback) {
 
 function extractTarballDownload(url, downloadFile, destination, options, callback) {
   if(!options) options = {}
-  var download = wget.download(url, downloadFile, options)
-  download.on('error', function(err){
-    callback('error', {error: err})
-  })
-  download.on('end', function(output) {
-    extractTarball(output, destination, function(err, data){
-      callback(null, {url: url, downloadFile: downloadFile, destination: destination})
+  wget(url,{output: downloadFile})
+    .then(function(result){
+      extractTarball(downloadFile, destination, function(err, data){
+        callback(null, {url: url, downloadFile: downloadFile, destination: destination})
+      })
+    }).catch(function(err){
+      callback('error', {error: err})
     })
-  })
 }
 
 exports.extractTarball = extractTarball


### PR DESCRIPTION
Because the `wget@0.0.1` release version would emit `end` event,
before store file finished, I change to use fork version
`node-wget-promise` for this bug patch, and this package is still be
maintained.